### PR TITLE
なんか色々

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="paea" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="java-net-repo" />
+      <option name="name" value="java-net-repo" />
+      <option name="url" value="https://repo.rumia.me/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="21" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
 			<artifactId>sqlite-jdbc</artifactId>
 			<version>3.50.3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.10.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/su/rumishistem/paea/Main.java
+++ b/src/main/java/su/rumishistem/paea/Main.java
@@ -26,7 +26,7 @@ public class Main {
 
 			default:
 				System.out.println("その実行ﾓｰﾄﾞはありません。");
-				System.out.println("");
+				System.out.println();
 				print_help();
 				return;
 		}

--- a/src/main/java/su/rumishistem/paea/Tool/InputChecker.java
+++ b/src/main/java/su/rumishistem/paea/Tool/InputChecker.java
@@ -3,9 +3,23 @@ package su.rumishistem.paea.Tool;
 import java.util.regex.Pattern;
 
 public class InputChecker {
+	/**
+	 * ホスト名の正規表現 (RFC 1123準拠)
+	 * - 各ラベルは1〜63文字
+	 * - 全体で253文字以内
+	 * - 英数字で始まり英数字で終わる（途中にハイフン可）
+	 */
+	private static final Pattern HOST_PATTERN = Pattern.compile(
+		"^" +
+		"(?=.{1,253}$)" +                                  // 全体の長さ制限
+		"(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)" + // 先頭ラベル
+		"(?:\\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*" + // 続くラベル
+		"$"
+	);
+
 	public static boolean is_host(String input) {
 		if (input == null) return false;
 
-		return Pattern.compile("^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$").matcher(input).matches();
+		return HOST_PATTERN.matcher(input).matches();
 	}
 }

--- a/src/main/java/su/rumishistem/paea/Tool/SQL.java
+++ b/src/main/java/su/rumishistem/paea/Tool/SQL.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 
 public class SQL {
-	private static final String SQL_PATH = "/etc/paea/main.db";
+	private static final String SQL_PATH = System.getProperty("user.home") + "/.config/paea/main.db";
 	private static final String SQL_URL = "jdbc:sqlite:" + SQL_PATH;
 
 	private static Connection connection;
@@ -78,21 +78,18 @@ public class SQL {
 		for (int I = 0; I < param_list.length; I++) {
 			Object Param = param_list[I];
 			//型に寄って動作をかえる
-			if(Param instanceof String){
-				//Stringなら
-				stmt.setString(I + 1, (String)Param);
-			} else if(Param instanceof Integer){
-				//Intなら
-				stmt.setInt(I + 1, (int)Param);
-			} else if (Param instanceof Long) {
-				stmt.setLong(I + 1, (long)Param);
-			} else if (Param instanceof  Boolean) {
-				stmt.setBoolean(I + 1, (boolean)Param);
-			} else if (Param == null) {
-				stmt.setNull(I + 1, Types.NULL);
-			} else {
-				throw new Error(Param.getClass().getSimpleName() + "という型は非対応です");
-			}
+            switch (Param) {
+                case String s ->
+                    //Stringなら
+                        stmt.setString(I + 1, s);
+                case Integer i ->
+                    //Intなら
+                        stmt.setInt(I + 1, (int) Param);
+                case Long l -> stmt.setLong(I + 1, (long) Param);
+                case Boolean b -> stmt.setBoolean(I + 1, (boolean) Param);
+                case null -> stmt.setNull(I + 1, Types.NULL);
+                default -> throw new Error(Param.getClass().getSimpleName() + "という型は非対応です");
+            }
 		}
 	}
 

--- a/src/test/java/su/rumishistem/paea/Tool/InputCheckerTest.java
+++ b/src/test/java/su/rumishistem/paea/Tool/InputCheckerTest.java
@@ -1,0 +1,27 @@
+package su.rumishistem.paea.Tool;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InputCheckerTest {
+    @Test
+    public void testIsHost() {
+        // Valid hosts
+        assertTrue(InputChecker.is_host("example.com"));
+        assertTrue(InputChecker.is_host("a.b.c"));
+        assertTrue(InputChecker.is_host("localhost"));
+        assertTrue(InputChecker.is_host("my-host.example.com"));
+        assertTrue(InputChecker.is_host("127.0.0.1")); // Technically matches the regex as labels
+        assertTrue(InputChecker.is_host("a".repeat(63) + ".com"));
+
+        // Invalid hosts
+        assertFalse(InputChecker.is_host(null));
+        assertFalse(InputChecker.is_host(""));
+        assertFalse(InputChecker.is_host("-example.com"));
+        assertFalse(InputChecker.is_host("example-.com"));
+        assertFalse(InputChecker.is_host("example.com-"));
+        assertFalse(InputChecker.is_host("a".repeat(64) + ".com")); // label too long
+        assertFalse(InputChecker.is_host("a".repeat(254))); // total length too long
+        assertFalse(InputChecker.is_host("exam_ple.com")); // underscore not allowed
+    }
+}


### PR DESCRIPTION
…-specific settings

- Refactor `InputChecker` to use a precompiled regex for host validation
- Add JUnit 5 dependencies to `pom.xml` and create unit test for `InputChecker.isHost`
- Change default SQLite database path to user-specific config directory
- Refactor `SQL` parameter binding to use Java 17 pattern matching for switch